### PR TITLE
fix: tracking configuration URL and error event handling

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -65,7 +65,7 @@ async function fetchRemoteConfig(
     const controller = new AbortController();
     const timeoutId = setTimeout(() => controller.abort(), 3000);
 
-    const response = await fetch(`${analyticsHost}/site/${siteId}/tracking-config`, {
+    const response = await fetch(`${analyticsHost}/site/tracking-config/${siteId}`, {
       signal: controller.signal,
     });
 

--- a/src/core.ts
+++ b/src/core.ts
@@ -95,8 +95,8 @@ export function track(
       page_title: document.title,
       referrer: document.referrer || "direct",
       type: eventType,
-      ...((eventType === "custom_event" || eventType === "performance") && { event_name: eventName }),
-      ...((eventType === "custom_event" || eventType === "outbound") && Object.keys(properties ?? {}).length > 0 && {
+      ...((eventType === "custom_event" || eventType === "performance" || eventType === "error") && { event_name: eventName }),
+      ...((eventType === "custom_event" || eventType === "outbound" || eventType === "error") && Object.keys(properties ?? {}).length > 0 && {
         properties: JSON.stringify(properties),
       }),
       ...(eventType === "performance" && webVitals && { ...webVitals }),


### PR DESCRIPTION
This PR fixes two issues:

### 1. Fixed tracking configuration endpoint URL

The URL to fetch the tracking configuration was incorrect. It has been corrected to match the proper server endpoint.

**Before:**
```typescript
/site/${siteId}/tracking-config
```

**After:**
```typescript
/site/tracking-config/${siteId}
```

**Reference:** https://github.com/rybbit-io/rybbit/blob/master/server/src/index.ts#L381

### 2. Include `event_name` and `properties` for `error` type events

Events with type `error` were not sending `event_name` and `properties`.

**Changes:**
- `event_name` is now included for `error` type events
- `properties` are now included for `error` type events

**Reference:** https://github.com/rybbit-io/rybbit/blob/master/server/src/services/tracker/trackEvent.ts#L142

## Checklist

- [x] Code tested locally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error event tracking to improve visibility into application issues.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->